### PR TITLE
Do `bower install` on `npm install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "tiny-lr": "^0.1.4",
     "watch": "^0.13.0"
   },
-  "scripts": {},
+  "scripts": {
+    "postinstall": "bower install --no-interactive --allow-root"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jbutko/AngularJS-Boilerplate.git"


### PR DESCRIPTION
Including a npm postinstall script to run `bower install` during the npm install process. Simplification.
