### PR TITLE
updated gulpfile so it recurses in image directory.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ var gulp            = require('gulp'),
 
 // optimize images
 gulp.task('images', function() {
-  return gulp.src('./images/*')
+  return gulp.src('./images/**/*')
     .pipe($.changed('./_build/images'))
     .pipe($.imagemin({
       optimizationLevel: 3,


### PR DESCRIPTION
The current gulpfile does not recurse into the file directory at all so if you have

```
images\svg\svg.svg
```

It will just be excluded from the final build

adding the 

```
**/* 
```

tells it to look for all the folders and files recursively.

Not sure if this is the best way to do it I've also seen 

```
return gulp.src('./images/**/*', {base:'./'})
```

as documented here
http://www.levihackwith.com/how-to-make-gulp-copy-a-directory-and-its-contents/
