### PR TITLE
Update gulp-sass to eliminate sass error when running gulp.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "gulp-notify": "^2.1.0",
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^3.0.1",
-    "gulp-sass": "^1.3.2",
+    "gulp-sass": "^2.1.0",
     "gulp-size": "^1.2.0",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-uglify": "^1.1.0",


### PR DESCRIPTION
The newest version of gulp-sass fixes the sass error when running gulp. Fixes #10 
