### PR TITLE
Save up to 50% build time

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,14 +184,7 @@ gulp.task('usemin', function() {
     .pipe($.htmlReplace({
       'templates': '<script type="text/javascript" src="js/templates.js"></script>'
     }))
-    .pipe($.usemin({
-      css: [$.minifyCss(), 'concat'],
-      libs: [$.uglify()],
-      nonangularlibs: [$.uglify()],
-      angularlibs: [$.uglify()],
-      appcomponents: [$.uglify()],
-      mainapp: [$.uglify()]
-    }))
+    .pipe($.usemin())
     .pipe(gulp.dest('./_build/'));
 });
 


### PR DESCRIPTION
Remove the redundant uglify and minify process from the "usemin" task, since they are already processed.
For me, the build went from 8s to 4s.
