### PR TITLE
FIX gulp sass compile problem

### DIFF
--- a/styles/modules/_alerts.scss
+++ b/styles/modules/_alerts.scss
@@ -8,7 +8,8 @@ Based on: Bones - github.com/eddiemachado/bones
 
 // alerts and notices
 %alert {
-
+  background: #fcf8e3;
+  color: #8a6d3b;
 }
 
 .alert-help {


### PR DESCRIPTION
We just need to have something in `%alert`, otherwise gulp won't compile the sass.
