### PR TITLE
Watch components templates in default gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,7 +239,7 @@ gulp.task('default', ['browser-sync', 'sass', 'minify-css'], function() {
       reload(file.path);
     }
   });
-  gulp.watch(['*.html', 'views/*.html'], ['bs-reload']);
+  gulp.watch(['*.html', 'components/**/*.html', 'views/*.html'], ['bs-reload']);
   gulp.watch(['app/*.js', 'components/**/*.js', 'js/*.js'], ['bs-reload']);
   gulp.watch('styles/**/*.scss', ['sass', 'minify-css']);
 });


### PR DESCRIPTION
For example components/directives/main-nav.html is not taken into account in watch task.