### PR TITLE
Fixed references to the OwlCarousel Slider assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 		<!-- CSS -->
 		<!-- build:css css/style.min.css -->
-		<link rel="stylesheet" href="bower_components/OwlCarousel/owl-carousel/owl.carousel.css" />
+		<link rel="stylesheet" href="bower_components/OwlCarousel/dist/assets/owl.carousel.css" />
 		<link rel="stylesheet" type="text/css" href="styles/style.css" />
 		<!-- endbuild -->
 
@@ -55,7 +55,7 @@
 	<!-- build:libs js/libs.js -->
 	<script type="text/javascript" src="js/nonangular/lodash.min.js"></script>
 	<script type="text/javascript" src="js/scripts.js"></script>
-	<script type="text/javascript" src="bower_components/OwlCarousel/owl-carousel/owl.carousel.min.js"></script>
+	<script type="text/javascript" src="bower_components/OwlCarousel/dist/owl.carousel.min.js"></script>
 	<!-- endbuild -->
 
 	<!-- Angular external libraries for application -->


### PR DESCRIPTION
I found when I installed and ran I had errors along the lines of

events.js:183
      throw er; // Unhandled 'error' event
      ^
Error: Path /home/user/AngularJS-Boilerplate/bower_components/OwlCarousel/dist/assets/owl.carousel.min.js not found!

So I fixed the reference. I think the file location was changed in the bower_component. 
